### PR TITLE
grep0001: adds Python module subsection

### DIFF
--- a/grep-0001-coding-guidelines.md
+++ b/grep-0001-coding-guidelines.md
@@ -111,6 +111,16 @@ and follow them.
   Python.
 * Pylint is good tool for helping with following code guidelines. It's very
   fussy though, so don't get too worked up about following its suggestions.
+  
+### Python modules
+
+* Make sure builds and tests work with only GNU Radio required components.
+  Mostly, this implies to only rely on `NumPy`.
+  Otherwise issues related to missing modules pop up repeatedly on the issue tracker.
+* Always keep in mind that modules like `SciPy` and `matplotlib` are optional.
+  If such a module is used without checking availability first, this will break
+  things for at least some users.
+
 
 ## Revision Control Guidelines
 


### PR DESCRIPTION
In the past some issues related to missing Python dependencies, especially SciPy, popped up on the issue tracker. These issues should be addressed here.

This addresses issue #6 